### PR TITLE
Change query_name to query.name to comply with pyhmmer >= 0.11.0

### DIFF
--- a/install_metacerberus.sh
+++ b/install_metacerberus.sh
@@ -10,7 +10,7 @@ eval "$(conda shell.bash hook)"
 
 # create the metacerberus environment in conda
 mamba create -y -n $ENV_NAME -c conda-forge -c bioconda \
-	python'>=3.8' setuptools"<70.0.0" hydrampp pyhmmer flash2 \
+	python'>=3.8' setuptools"<70.0.0" hydrampp pyhmmer">=0.11.0" flash2 \
 	pyrodigal pyrodigal-gv \
 	metaomestats plotly scikit-learn dominate python-kaleido configargparse psutil pandas \
 	fastqc flash2 fastp porechop bbmap trnascan-se phanotate \

--- a/lib/metacerberus_hmm.py
+++ b/lib/metacerberus_hmm.py
@@ -44,7 +44,7 @@ def searchHMM(aminoAcids:dict, config:dict, subdir:str, hmm:tuple, CPUs:int=4):
                         if domain.score < minscore:
                             continue
                         align = domain.alignment
-                        print(h.name.decode(), hit.query_name.decode(), f'{h.evalue:.1E}', f"{domain.score:.1f}", h.length,
+                        print(h.name.decode(), hit.query.name.decode(), f'{h.evalue:.1E}', f"{domain.score:.1f}", h.length,  # since pyhmmer v0.11.0, "query_name" has been removed. Use "hit.query.name" instead.
                             align.target_from, align.target_to,
                             sep='\t', file=hmm_writer)
         outlist += [outfile]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     install_requires=[
             'setuptools',
             'pandas',
-            'pyhmmer',
+            'pyhmmer>=0.11.0',
             'hydrampp',
             'pyrodigal',
             'pyrodigal-gv',


### PR DESCRIPTION
From pyhmmer 0.11.0, `query_name` has been removed (https://github.com/althonos/pyhmmer/releases/tag/v0.11.0) and `query.name` should be used instead. Based on the current settings, the updated version of pyhmmer will be installed, which will lead to an error: AttributeError: 'pyhmmer.plan7.TopHits' object has no attribute 'query_name'. I also added some restrictions on the pyhmmer version just in case an old version is installed.
